### PR TITLE
Use WinRPM for Windows binaries

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.4-
 BinDeps
+@windows WinRPM

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -22,11 +22,10 @@ provides(Sources,
          libgit2,
          unpacked_dir="libgit2-$version")
 
-# Windows binaries built in MSYS2 via:
-# /d/code/CMake-2.8/bin/cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/usr -G"MSYS Makefiles"
-# /d/code/CMake-2.8/bin/cmake --build . --target install
-provides(Binaries, URI("http://sourceforge.net/projects/juliadeps-win/files/libgit2-v$version.7z"),
-         libgit2, unpacked_dir="usr$WORD_SIZE/bin", os = :Windows)
+@windows_only begin
+    using WinRPM
+    provides(WinRPM.RPM, "libgit2", [libgit2], os = :Windows)
+end
 
 prefix = joinpath(BinDeps.depsdir(libgit2),"usr")
 srcdir = joinpath(BinDeps.depsdir(libgit2),"src","libgit2-$version")


### PR DESCRIPTION
I put libgit2 up on WinRPM. It's at 0.21.3 right now. This is easier to update in the future using the github-like interface on the openSUSE build service here: https://build.opensuse.org/package/show/windows:mingw:win64/mingw64-libgit2 and https://build.opensuse.org/package/show/windows:mingw:win32/mingw32-libgit2

WIP until AppVeyor runs on it.